### PR TITLE
OVN to Open Voice Network

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -42,7 +42,7 @@ values:
 about:
   heading: For the Future of Voice Assistance
   text: >-
-    Become an OVN sponsoring member.  Doing so allows you to advocate for and finally support the mission of the Open Voice Network.  Sponsoring members will guide and shape the future of voice assistance – in increasingly critical issues of technology, competition, and commercial and personal data privacy – to the benefit of global users and providers.
+    Become an Open Voice Network sponsoring member.  Doing so allows you to advocate for and finally support the mission of the Open Voice Network.  Sponsoring members will guide and shape the future of voice assistance – in increasingly critical issues of technology, competition, and commercial and personal data privacy – to the benefit of global users and providers.
 social:
   heading: The Open Voice Network in Social Media
   text: >-

--- a/site/content/about/_index.md
+++ b/site/content/about/_index.md
@@ -5,7 +5,7 @@ about:
   - heading: Vision
     imageUrl: /img/1x1-white-pixel.png
     text: >-
-      The Open Voice Network (OVN) is dedicated to making voice assistance worthy of user 
+      The Open Voice Network is dedicated to making voice assistance worthy of user 
       trust—especially for a future of voice assistance that will be multi-assistant, 
       multi-platform, multi-device, multi-modal, and multi-use.
   - heading: Mission
@@ -36,9 +36,9 @@ about:
   - heading: Governance
     imageUrl: /img/1x1-white-pixel.png
     textHTML: >-
-      <p>The Open Voice Network (OVN) is an independently funded and governed non-profit industry association which operates as a directed fund of the Linux Foundation. </p>
-      <p>Financial support for the OVN comes from sponsoring enterprises and entities. Strategic direction, by a Steering Committee comprised of senior executives of sponsor organizations.  Day-to-day management is provided by an Executive Director who reports to the Steering Committee, as well as the chairs of OVN standing committees and moderators of OVN communities. </p>
-      <p>As a directed fund of the Linux Foundation, the OVN enjoys access to the expertise, and shared legal, operational, and marketing services, of the LF, a world leader in the creation of open source projects and ecosystems.</p>
+      <p>The Open Voice Network is an independently funded and governed non-profit industry association which operates as a directed fund of the Linux Foundation. </p>
+      <p>Financial support for The Open Voice Network comes from sponsoring enterprises and entities. Strategic direction, by a Steering Committee comprised of senior executives of sponsor organizations.  Day-to-day management is provided by an Executive Director who reports to the Steering Committee, as well as the chairs of The Open Voice Network standing committees and moderators of The Open Voice Network communities. </p>
+      <p>As a directed fund of the Linux Foundation, The Open Voice Network enjoys access to the expertise, and shared legal, operational, and marketing services, of the LF, a world leader in the creation of open source projects and ecosystems.</p>
   - heading: About the Linux Foundation
     imageUrl: /img/1x1-white-pixel.png
     textHTML: >-
@@ -82,5 +82,5 @@ about:
       - heading: Jon Stine,
         subHeading: Executive Director of Open Voice Network
         text: >-
-          Champions the mission and vision of the broader OVN community
+          Champions the mission and vision of the broader Open Voice Network community
 ---

--- a/site/content/about/_index.md
+++ b/site/content/about/_index.md
@@ -32,13 +32,13 @@ about:
       Technology (MIT) Auto-ID Laboratory, Capgemini Consulting, and the Intel
       Corporation.   In late 2018, seed funding was provided to initiate
       research into voice assistance technologies and potential standards, and
-      to develop The Open Voice Network.</p>
+      to develop the Open Voice Network.</p>
   - heading: Governance
     imageUrl: /img/1x1-white-pixel.png
     textHTML: >-
       <p>The Open Voice Network is an independently funded and governed non-profit industry association which operates as a directed fund of the Linux Foundation. </p>
-      <p>Financial support for The Open Voice Network comes from sponsoring enterprises and entities. Strategic direction, by a Steering Committee comprised of senior executives of sponsor organizations.  Day-to-day management is provided by an Executive Director who reports to the Steering Committee, as well as the chairs of The Open Voice Network standing committees and moderators of The Open Voice Network communities. </p>
-      <p>As a directed fund of the Linux Foundation, The Open Voice Network enjoys access to the expertise, and shared legal, operational, and marketing services, of the LF, a world leader in the creation of open source projects and ecosystems.</p>
+      <p>Financial support for the Open Voice Network comes from sponsoring enterprises and entities. Strategic direction, by a Steering Committee comprised of senior executives of sponsor organizations.  Day-to-day management is provided by an Executive Director who reports to the Steering Committee, as well as the chairs of the Open Voice Network standing committees and moderators of the Open Voice Network communities. </p>
+      <p>As a directed fund of the Linux Foundation, the Open Voice Network enjoys access to the expertise, and shared legal, operational, and marketing services, of the LF, a world leader in the creation of open source projects and ecosystems.</p>
   - heading: About the Linux Foundation
     imageUrl: /img/1x1-white-pixel.png
     textHTML: >-

--- a/site/content/friends-of-the-open-voice-network/_index.md
+++ b/site/content/friends-of-the-open-voice-network/_index.md
@@ -50,11 +50,11 @@ hardsell:
       inclusivity to voice through the development and adoption of standards
       will dramatically expand opportunities for the voice ecosystem. And those
       who help create standards and bring them to market be taking a step ahead
-      in a highly competitive environment. <br><br> Friends of the OVN today
+      in a highly competitive environment. <br><br> Friends of The Open Voice Network today
       bring invaluable leadership and expertise to our Work Groups and
       Communities. We welcome your participation, and this public demonstration
       of support.
-    heading: Why Become a Friend of the Open Voice Network
+    heading: Why Become a Friend of The Open Voice Network
 pricing:
   description: ' '
   heading: ' '

--- a/site/content/friends-of-the-open-voice-network/_index.md
+++ b/site/content/friends-of-the-open-voice-network/_index.md
@@ -50,11 +50,11 @@ hardsell:
       inclusivity to voice through the development and adoption of standards
       will dramatically expand opportunities for the voice ecosystem. And those
       who help create standards and bring them to market be taking a step ahead
-      in a highly competitive environment. <br><br> Friends of The Open Voice Network today
+      in a highly competitive environment. <br><br> Friends of the Open Voice Network today
       bring invaluable leadership and expertise to our Work Groups and
       Communities. We welcome your participation, and this public demonstration
       of support.
-    heading: Why Become a Friend of The Open Voice Network
+    heading: Why Become a Friend of the Open Voice Network
 pricing:
   description: ' '
   heading: ' '

--- a/site/content/join/_index.md
+++ b/site/content/join/_index.md
@@ -6,7 +6,7 @@ hardsell:
     description: >-
       The industry surrounding voice technology is at an inflection point. Innovation by voice tech experience strategists, designers, and developers has demonstrated tremendous potential to include and serve society at large, inclusive of many levels of literacy or physical and cognitive abilities. It has also raised questions about interoperability, ethical use, and standards to ensure voice tech is a trustworthy interface developed for the benefit of the many, as opposed to the few. Supporting the Open Voice Network’s work to recommend standards for interoperability and effective, ethical use of voice AI is vital  to growing the industry in a way that can offer society the full benefits of using speech to engage with the digital world.    
       <br><br>
-      Opportunities to get involved within The Open Voice Network are open to individuals willing to give of their time, network, industry knowledge, and resources through collaboration, advocacy, and development of standards. Enterprises are invited to join The Open Voice Network as Sponsoring Members by providing financial sponsorship as well as executive leadership. Contact us to learn more.
+      Opportunities to get involved within the Open Voice Network are open to individuals willing to give of their time, network, industry knowledge, and resources through collaboration, advocacy, and development of standards. Enterprises are invited to join the Open Voice Network as Sponsoring Members by providing financial sponsorship as well as executive leadership. Contact us to learn more.
 testimonials:
   - author: >-
       Kees Jacobs | Vice-President for Global Consumer Products & Retail,

--- a/site/content/join/_index.md
+++ b/site/content/join/_index.md
@@ -6,7 +6,7 @@ hardsell:
     description: >-
       The industry surrounding voice technology is at an inflection point. Innovation by voice tech experience strategists, designers, and developers has demonstrated tremendous potential to include and serve society at large, inclusive of many levels of literacy or physical and cognitive abilities. It has also raised questions about interoperability, ethical use, and standards to ensure voice tech is a trustworthy interface developed for the benefit of the many, as opposed to the few. Supporting the Open Voice Network’s work to recommend standards for interoperability and effective, ethical use of voice AI is vital  to growing the industry in a way that can offer society the full benefits of using speech to engage with the digital world.    
       <br><br>
-      Opportunities to get involved within OVN are open to individuals willing to give of their time, network, industry knowledge, and resources through collaboration, advocacy, and development of standards. Enterprises are invited to join OVN as Sponsoring Members by providing financial sponsorship as well as executive leadership. Contact us to learn more.
+      Opportunities to get involved within The Open Voice Network are open to individuals willing to give of their time, network, industry knowledge, and resources through collaboration, advocacy, and development of standards. Enterprises are invited to join The Open Voice Network as Sponsoring Members by providing financial sponsorship as well as executive leadership. Contact us to learn more.
 testimonials:
   - author: >-
       Kees Jacobs | Vice-President for Global Consumer Products & Retail,

--- a/site/content/resources/_index.md
+++ b/site/content/resources/_index.md
@@ -21,7 +21,7 @@ intro:
       buttonText: Learn More
       buttonLink: https://voicefirsthealth.com/digital-health-law-making-with-bianca-phillips-2/
       text: >-
-        OVN Ambassador Bianca Phillips shares her research on the Voice First Health Podcast. 
+        The Open Voice Network Ambassador Bianca Phillips shares her research on the Voice First Health Podcast. 
       title: >-
         Digital Health Law Making (Bianca Phillips) 
 ---

--- a/site/content/sponsoring_member/_index.md
+++ b/site/content/sponsoring_member/_index.md
@@ -4,33 +4,33 @@ image: /img/ovn-open-voice-network-join-ai-voice-assistance_optimized.jpg
 hardsell:
   - heading: 
     description: >-
-      Is your enterprise or organization interested in contributing to The Open Voice Network’s mission? We encourage you to become a Sponsoring Member of the Open Voice Network.
+      Is your enterprise or organization interested in contributing to the Open Voice Network’s mission? We encourage you to become a Sponsoring Member of the Open Voice Network.
       <br><br>
       Sponsoring Members are enterprises that provide financial support and executive leadership to the Open Voice Network. Sponsorship is open worldwide to enterprises and public entities, as well as those that advise or represent such enterprises and entities.
       <br><br>
-      The sponsorship tier breakdown for The Open Voice Network Sponsoring Membership is as follows:
+      The sponsorship tier breakdown for the Open Voice Network Sponsoring Membership is as follows:
 pricing:
   description: ""
   heading: ""
-  footnote: "* Sponsoring Memberships are for enterprises only. If you would like to become individually involved with the Open Voice Network, please visit our Friends of The Open Voice Network page."
+  footnote: "* Sponsoring Memberships are for enterprises only. If you would like to become individually involved with the Open Voice Network, please visit our Friends of the Open Voice Network page."
   plans:
     - description: ' USD per annum | Total of $300,000 USD across a three-year commitment'
       items:
-        - The Open Voice Network Platinum Sponsors serve on The Open Voice Network Steering Committee
+        - The Open Voice Network Platinum Sponsors serve on the Open Voice Network Steering Committee
         - Serve on and guide other Open Voice Network decision-making bodies
         - Advise and guide Open Voice standards-centric research
       plan: OPEN VOICE NETWORK PLATINUM SPONSORS
       price: '100,000'
     - description: ' USD per annum | Total of $150,000 USD across a three-year commitment'
       items:
-        - Represented on The Open Voice Network Steering Committee
+        - Represented on the Open Voice Network Steering Committee
         - May participate in other Open Voice Network committees
       plan: OPEN VOICE NETWORK GOLD SPONSORS
       price: '50,000'
     - description: ' USD per annum | Total of $22,500 USD across a three-year commitment'
       items:
         - Voice-centric and/or relevant early-stage technology firms
-        - Represented on The Open Voice Network Steering Committee
+        - Represented on the Open Voice Network Steering Committee
         - May participate in other Open Voice Network committees
       plan: 'OPEN VOICE NETWORK ADVOCATES '
       price: '7,500'
@@ -57,7 +57,7 @@ intro:
   description: >-
     The Open Voice Network will sponsor research that will explore, develop, and assert standards and technologies of open voice. Contributions from Sponsoring Members will help shape the future of voice AI in areas of technology, value propositions, provider ecosystems, competition, and commercial and personal information privacy. 
     <br><br>
-    A Sponsoring Membership with The Open Voice Network will also allow senior executives from your enterprise or organization to participate in industry symposia on research and best practices in voice-AI commerce, as well as gain first access to the Open Voice Network standards development, use case research by leading academic institutions and consultancies, and networking with voice-AI leaders and innovators within consumer-facing industries. 
+    A Sponsoring Membership with the Open Voice Network will also allow senior executives from your enterprise or organization to participate in industry symposia on research and best practices in voice-AI commerce, as well as gain first access to the Open Voice Network standards development, use case research by leading academic institutions and consultancies, and networking with voice-AI leaders and innovators within consumer-facing industries. 
   heading: Why Become a Member of Open Voice Network?
 ---
 

--- a/site/content/sponsoring_member/_index.md
+++ b/site/content/sponsoring_member/_index.md
@@ -4,35 +4,35 @@ image: /img/ovn-open-voice-network-join-ai-voice-assistance_optimized.jpg
 hardsell:
   - heading: 
     description: >-
-      Is your enterprise or organization interested in contributing to OVN’s mission? We encourage you to become a Sponsoring Member of the Open Voice Network.
+      Is your enterprise or organization interested in contributing to The Open Voice Network’s mission? We encourage you to become a Sponsoring Member of the Open Voice Network.
       <br><br>
       Sponsoring Members are enterprises that provide financial support and executive leadership to the Open Voice Network. Sponsorship is open worldwide to enterprises and public entities, as well as those that advise or represent such enterprises and entities.
       <br><br>
-      The sponsorship tier breakdown for OVN Sponsoring Membership is as follows:
+      The sponsorship tier breakdown for The Open Voice Network Sponsoring Membership is as follows:
 pricing:
   description: ""
   heading: ""
-  footnote: "* Sponsoring Memberships are for enterprises only. If you would like to become individually involved with the Open Voice Network, please visit our Friends of OVN page."
+  footnote: "* Sponsoring Memberships are for enterprises only. If you would like to become individually involved with the Open Voice Network, please visit our Friends of The Open Voice Network page."
   plans:
     - description: ' USD per annum | Total of $300,000 USD across a three-year commitment'
       items:
-        - OVN Platinum Sponsors serve on the OVN Steering Committee
-        - Serve on and guide other OVN decision-making bodies
+        - The Open Voice Network Platinum Sponsors serve on The Open Voice Network Steering Committee
+        - Serve on and guide other Open Voice Network decision-making bodies
         - Advise and guide Open Voice standards-centric research
-      plan: OVN PLATINUM SPONSORS
+      plan: OPEN VOICE NETWORK PLATINUM SPONSORS
       price: '100,000'
     - description: ' USD per annum | Total of $150,000 USD across a three-year commitment'
       items:
-        - Represented on the OVN Steering Committee
-        - May participate in other OVN committees
-      plan: OVN GOLD SPONSORS
+        - Represented on The Open Voice Network Steering Committee
+        - May participate in other Open Voice Network committees
+      plan: OPEN VOICE NETWORK GOLD SPONSORS
       price: '50,000'
     - description: ' USD per annum | Total of $22,500 USD across a three-year commitment'
       items:
         - Voice-centric and/or relevant early-stage technology firms
-        - Represented on the OVN Steering Committee
-        - May participate in other OVN committees
-      plan: 'OVN ADVOCATES '
+        - Represented on The Open Voice Network Steering Committee
+        - May participate in other Open Voice Network committees
+      plan: 'OPEN VOICE NETWORK ADVOCATES '
       price: '7,500'
 testimonials:
   - author: Jon Stine | Executive Director of Open Voice Network
@@ -55,9 +55,9 @@ intro:
         and use case research by leading academic institutions and
         consultancies.
   description: >-
-    OVN will sponsor research that will explore, develop, and assert standards and technologies of open voice. Contributions from Sponsoring Members will help shape the future of voice AI in areas of technology, value propositions, provider ecosystems, competition, and commercial and personal information privacy. 
+    The Open Voice Network will sponsor research that will explore, develop, and assert standards and technologies of open voice. Contributions from Sponsoring Members will help shape the future of voice AI in areas of technology, value propositions, provider ecosystems, competition, and commercial and personal information privacy. 
     <br><br>
-    A Sponsoring Membership with OVN will also allow senior executives from your enterprise or organization to participate in industry symposia on research and best practices in voice-AI commerce, as well as gain first access to the Open Voice Network standards development, use case research by leading academic institutions and consultancies, and networking with voice-AI leaders and innovators within consumer-facing industries. 
+    A Sponsoring Membership with The Open Voice Network will also allow senior executives from your enterprise or organization to participate in industry symposia on research and best practices in voice-AI commerce, as well as gain first access to the Open Voice Network standards development, use case research by leading academic institutions and consultancies, and networking with voice-AI leaders and innovators within consumer-facing industries. 
   heading: Why Become a Member of Open Voice Network?
 ---
 

--- a/site/layouts/partials/contact-form.html
+++ b/site/layouts/partials/contact-form.html
@@ -24,7 +24,7 @@
       <select class="br1 w-100 db h2 f6 bg-grey-2 b--grey-2" name="interested" id="interested">
         <option value="">Interest In</option>
         <option value="Become a Sponsoring Member or Supporter">Become a Sponsoring Member or Supporter</option>
-        <option value="If You're a Supporter: Join an OVN Community">If You're a Supporter: Join an OVN Community</option>
+        <option value="If You're a Supporter: Join an Open Voice Network Community">If You're a Supporter: Join an Open Voice Network Community</option>
         <option value="Share Research">Share Research</option>
         <option value="News Media Inquiry">News Media Inquiry</option>
       </select>

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -6,7 +6,7 @@
 
 			<img src="/img/logo.svg" alt="Open Voice Network logo" class="db w4 center mb4 br0">
 			<p class="f3 lh-title light-gray b tc mb2">Newsletter subscribe</p>
-			<p>Get news from us in your inbox on a regular basis. Be the first to learn the latest with The Open Voice Network.</p>
+			<p>Get news from us in your inbox on a regular basis. Be the first to learn the latest with the Open Voice Network.</p>
 
 			{{ partial "newsletter-form" . }}
 

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -6,7 +6,7 @@
 
 			<img src="/img/logo.svg" alt="Open Voice Network logo" class="db w4 center mb4 br0">
 			<p class="f3 lh-title light-gray b tc mb2">Newsletter subscribe</p>
-			<p>Get news from us in your inbox on a regular basis. Be the first to learn the latest with the OVN.</p>
+			<p>Get news from us in your inbox on a regular basis. Be the first to learn the latest with The Open Voice Network.</p>
 
 			{{ partial "newsletter-form" . }}
 

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -23,7 +23,7 @@
 			<li><a href="/join" class="">Join</a>
 				<ul>
 					<li><a href="/sponsoring_member" class="">Sponsoring Member</a></li>
-					<li><a href="/friends-of-the-open-voice-network" class="">Friends of The Open Voice Network</a></li>
+					<li><a href="/friends-of-the-open-voice-network" class="">Friends of the Open Voice Network</a></li>
 					<li><a href="/communities" class="">Communities</a></li>
 				</ul>
 			</li>
@@ -51,7 +51,7 @@
 			<li><a href="/join" class="">Join</a>
 				<ul>
 					<li><a href="/sponsoring_member" class="">Sponsoring Member</a></li>
-					<li><a href="/friends-of-the-open-voice-network" class="">Friends of The Open Voice Network</a></li>
+					<li><a href="/friends-of-the-open-voice-network" class="">Friends of the Open Voice Network</a></li>
 					<li><a href="/communities" class="">Communities</a></li>
 				</ul>
 			</li>

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -23,7 +23,7 @@
 			<li><a href="/join" class="">Join</a>
 				<ul>
 					<li><a href="/sponsoring_member" class="">Sponsoring Member</a></li>
-					<li><a href="/friends-of-the-open-voice-network" class="">Friends of OVN</a></li>
+					<li><a href="/friends-of-the-open-voice-network" class="">Friends of The Open Voice Network</a></li>
 					<li><a href="/communities" class="">Communities</a></li>
 				</ul>
 			</li>
@@ -51,7 +51,7 @@
 			<li><a href="/join" class="">Join</a>
 				<ul>
 					<li><a href="/sponsoring_member" class="">Sponsoring Member</a></li>
-					<li><a href="/friends-of-the-open-voice-network" class="">Friends of OVN</a></li>
+					<li><a href="/friends-of-the-open-voice-network" class="">Friends of The Open Voice Network</a></li>
 					<li><a href="/communities" class="">Communities</a></li>
 				</ul>
 			</li>

--- a/site/layouts/section/join.html
+++ b/site/layouts/section/join.html
@@ -17,7 +17,7 @@
 			<a class="btn-link" href="/sponsoring_member">SPONSORING MEMBER</a>
 		</div>
 		<div class="w-100 w-50-ns">
-			<a class="btn-link" href="/friends-of-the-open-voice-network">FRIENDS OF OVN</a>
+			<a class="btn-link" href="/friends-of-the-open-voice-network">FRIENDS OF THE OPEN VOICE NETWORK</a>
 		</div>
 		<div class="w-100 w-50-ns">
 			<a class="btn-link" href="/communities">COMMUNITIES</a>

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -178,7 +178,7 @@ collections: # A list of collections the CMS should be able to edit
           - {label: Full_image, name: full_image, widget: image}
           - {label: Intro, name: intro, widget: object, fields: [{label: Heading, name: heading, widget: string}, {label: Description, name: description, widget: text}, {label: Blurbs, name: blurbs, widget: list, fields: [{label: Image, name: image, widget: image}, {label: Text, name: text, widget: text}]}]}
       - file: "site/content/supporters/_index.md"
-        label: "Friends of OVN"
+        label: "Friends of The Open Voice Network"
         name: "friends-of-the-open-voice-network"
         fields:
           - {label: Title, name: title, widget: string}

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -178,7 +178,7 @@ collections: # A list of collections the CMS should be able to edit
           - {label: Full_image, name: full_image, widget: image}
           - {label: Intro, name: intro, widget: object, fields: [{label: Heading, name: heading, widget: string}, {label: Description, name: description, widget: text}, {label: Blurbs, name: blurbs, widget: list, fields: [{label: Image, name: image, widget: image}, {label: Text, name: text, widget: text}]}]}
       - file: "site/content/supporters/_index.md"
-        label: "Friends of The Open Voice Network"
+        label: "Friends of the Open Voice Network"
         name: "friends-of-the-open-voice-network"
         fields:
           - {label: Title, name: title, widget: string}


### PR DESCRIPTION
Due to a legal issue, the Open Voice Network told us they will need to remove "OVN" everywhere on their site and replace it with "The Open Voice Network" or "Open Voice Network" where needed.
