### PR TITLE
add photos and fix admin advisor so we keep photos on edit

### DIFF
--- a/site/content/industry-advisor-council/_index.md
+++ b/site/content/industry-advisor-council/_index.md
@@ -10,5 +10,43 @@ about:
       key advisors are important to the outreach of the Open Voice Network
       through their notable platforms and experience within their respective
       industries.
+advisor:
+  - heading: Manolo Almagro
+    imageUrl: /img/industry-advisor-council/open-voice-network-ovn-industry-advisors-council-Manolo-Almagro.png
+    text: >-
+      Manolo Almagro is a 25+ year veteran in retail technology and leads Q Division—a global team of business management consultants, digital commerce and transformative tech experts who help companies choose the best strategies, find the right technology and accelerate digital transformation.
+      <br><br>
+      Among his technical achievements, Manolo is a named inventor on retail software patent US #6038545 and was recognized by Infocom/AVIXA as an inaugural Emerging Trend Fellow.
+      <br><br>
+      Manolo is a regular industry speaker for global trade events such as CES and NRF. Manny also speaks at Aviation World, Infocom, Euroshop, and MWC Barcelona.  
+  - heading: Joti Balani
+    imageUrl: /img/industry-advisor-council/open-voice-network-ovn-industry-advisors-council-joti-balani.jpeg
+    text: >-
+      Joti Balani is Founder & Managing Director of <a href="https://freshriver.ai" target="_blank">Freshriver.ai</a>, an Enterprise-grade AI and Data Science consultancy focused on building custom, human-centered AI assistants that generate emotional, economic and brand value. She has helped drive complex enterprise transformations with AI and data-driven personalized customer experience, authentic engagement, revenue generation and cost optimizations. She has led such transformative innovation at Fortune 100 enterprises such as Lowe’s, Citigroup, American Red Cross and is also Technical Advisor to <a href="https://fempeak.ai" target="_blank">Fempeak.ai</a>, a startup focused on raising women’s socioeconomic status through the application of AI and Data Science.
+      <br><br>
+      Joti also leads the Open Voice Network’s Industry Advisory Council and is co-founder of the Women in Voice New Jersey chapter. She can be reached at <a href="https://www.linkedin.com/in/jotibalani" target="_blank">www.linkedin.com/in/jotibalani</a>.
+  - heading: Donald Buckley
+    imageUrl: /img/industry-advisor-council/open-voice-network-ovn-industry-advisors-council-donald-buckley.jpg
+    text: >-
+      As Chief Marketing Officer of Showtime Networks Inc., Donald Buckley led marketing for series including Homeland, Billions and Shameless, Showtime Sports and Showtime Documentary Films. He created and led the marketing organization that launched Showtime's Streaming OTT service in 2015. Previously, as Warner Bros.' SVP, Interactive Marketing, Buckley founded its Interactive Marketing department. Among the hundreds of movies released during Buckley's tenure were the Harry Potter and The Dark Knight franchises. He is a member of the Academy of Motion Picture Arts and Sciences and the Television Academy of Arts and Sciences and currently advisor to a number of media companies and startups in voice-tech, gaming, TV, content, social, data security, app development and research.
+  - heading: Hans van Dam
+    imageUrl: /img/industry-advisor-council/open-voice-network-ovn-industry-advisors-council-hans-van-dam.jpg
+    text: >-
+      Hans van Dam is co-founder and Dean of the <a href="https://www.conversationdesigninstitute.com/" target="_blank">Conversation Design Institute</a>, the world’s leading
+      training and certification institute for conversation designers. The Conversation Design
+      Institute works with brands like Walmart, JP Morgan, Google, ABN AMRO, and many others, to
+      make their AI Assistants more human-centric, helpful, and natural. Hans van Dam lectures at
+      multiple universities (VU, University of Nijmegen, Goldsmiths) and speaks often at
+      conferences around the world.
+  - heading: Bradley Metrock
+    imageUrl: /img/industry-advisor-council/open-voice-network-ovn-industry-advisors-council-bradley-metrock.jpg
+    text: >-
+      Bradley Metrock is CEO of <a href="https://www.projectvoice.ai/" target="_blank">Project Voice</a>, which drives global business for voice tech and conversational AI companies. Metrock writes the popular newsletter <a href="https://thisweekinvoice.substack.com/" target="_blank">This Week In Voice VIP</a> and co-hosts the weekly internet TV show _This Week In Voice Live_. He splits time between Nashville, Tennessee, and Birmingham, Alabama.
+  - heading: Gwen Morrison
+    imageUrl: /img/industry-advisor-council/open-voice-network-ovn-industry-advisors-council-Gwen-Morrison.jpeg
+    text: >-
+      As a partner with <a href="https://candezent.com/" target="_blank">Candezant Advisory</a>, Gwen Morrison consults retail tech start-up companies and is an Ambassador of the Open Voice Network where she co-leads the Commerce Community.
+      <br><br>
+      As CEO for <a href="https://thestore.wpp.com/" target="_blank">WPP’s Global Retail Practice</a>, Gwen spent over 15 years helping clients and agencies navigate the dynamic retail environment across the world.  She has worked with major international brands across CPG, Retail, Banking and Automotive and has led industry research in emerging markets. Gwen is a frequent speaker at international conferences including National Retail Federation, CES, and Retail Leaders Forum in Sydney Gwen also guest lectures at Northwestern University, U of C Berkley and University of Arizona. 
 ---
 

--- a/site/content/voice_interoperability_form/_index.md
+++ b/site/content/voice_interoperability_form/_index.md
@@ -10,12 +10,16 @@ description: >-
   below.</center></strong><br></p> 
 
 
-  <div style="text-align:center; max-width: 913px;"><a
+  <div class="mw7 center ph3 pt4">
+    <div class="flex-ns flex-wrap">
+    <a
   href="https://drive.google.com/file/d/1qPnzNdmeFd-3krTwEtW7u4BptDI3qX37/view?usp=sharing"
-  target="_blank"><img
+  target="_blank"><img class="text-center"
   src="img/open-voice-network-voice-agent-interoperability-workshop-manifesto.png"
-  align="center"></a></div>
-
+  align="center"></a>
+    </div>
+  </div>
+  
 
   <div class="row" style="text-align:center;">
       <div class="col-md-12 text-center" style="max-width: 100%";>

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -214,7 +214,7 @@ collections: # A list of collections the CMS should be able to edit
               - {label: Text, name: text, widget: text}
               - {label: Image, name: imageUrl, widget: image}
           - label: Advisors
-            name: advisors
+            name: advisor
             widget: list
             fields:
               - {label: Heading, name: heading, widget: string}


### PR DESCRIPTION
Can you help us with another small edit? We had to revise the Workshops page and we're having trouble getting an image aligned on the page. Can you take a look (the short/wide image near the top) and see if you're able to center it? If possible, we would like to keep the ability for the button to open a new tab.
> yes see preview

We also merged the previous PR and it looks like the Industry Advisory Council images are missing from the page. Can you take a look at that when you have a chance too?
> yes and I also updated the admin config to hopefully keep the images on next edit.