### PR TITLE
update sponsor member pricing

### DIFF
--- a/site/content/sponsoring_member/_index.md
+++ b/site/content/sponsoring_member/_index.md
@@ -29,7 +29,6 @@ pricing:
       price: '50,000'
     - description: ' USD per annum | Total of $75,00 USD across a three-year commitment'
       items:
-        - Voice-centric and/or relevant early-stage technology firms
         - Active voice in standards decision-making and Open Voice Network outreach
       plan: 'OPEN VOICE NETWORK SUPPORTERS'
       price: '25,000'

--- a/site/content/sponsoring_member/_index.md
+++ b/site/content/sponsoring_member/_index.md
@@ -27,13 +27,12 @@ pricing:
         - May participate in other Open Voice Network committees
       plan: OPEN VOICE NETWORK GOLD SPONSORS
       price: '50,000'
-    - description: ' USD per annum | Total of $22,500 USD across a three-year commitment'
+    - description: ' USD per annum | Total of $75,00 USD across a three-year commitment'
       items:
         - Voice-centric and/or relevant early-stage technology firms
-        - Represented on the Open Voice Network Steering Committee
-        - May participate in other Open Voice Network committees
-      plan: 'OPEN VOICE NETWORK ADVOCATES '
-      price: '7,500'
+        - Active voice in standards decision-making and Open Voice Network outreach
+      plan: 'OPEN VOICE NETWORK SUPPORTERS'
+      price: '25,000'
 testimonials:
   - author: Jon Stine | Executive Director of Open Voice Network
     quote: >-


### PR DESCRIPTION
OVN reached out to us asking if we could make an additional change on the Sponsoring Members page -- can you help us with this? The far right column needs to change in these ways:

Open Voice Network Advocates --> Open Voice Network Supporters
$7,500 --> $25,000
$22,500 --> $75,000

Then we can remove all three of the phrases underneath ("Voice-centric..." "Represented on..." "May participate...") and replace them with "Active voice in standards decision-making and Open Voice Network outreach"