### PR TITLE
change page names

### DIFF
--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -19,8 +19,8 @@
 				<ul class="mb3">
 					<li><a href="/" class="link">Home</a></li>
 					<li><a href="/join" class="link">How to join</a></li>
-					<li><a href="/about" class="link">About</a></li>
-					<li><a href="/post" class="link">Blog</a></li>
+					<li><a href="/about" class="link">About Us</a></li>
+					<li><a href="/post" class="link">News and Media</a></li>
 					<li><a href="/contact" class="link">Contact</a></li>
 				</ul>
 			</div>

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -14,7 +14,7 @@
 		</button>
 
 		<ul class="navbar">
-			<li><a href="/about" class="">About</a>
+			<li><a href="/about" class="">About Us</a>
 				<ul>
 					<li><a href="/ambassadors" class="">Ambassadors</a></li>
 					<li><a href="/industry-advisor-council" class="">Industry Advisor Council</a></li>
@@ -29,7 +29,7 @@
 				</ul>
 			</li>
 			
-			<li><a href="/resources" class="">Resources</a>
+			<li><a href="/resources" class="">Messaging</a>
 				<ul>
 					<li><a href="/faq" class="">FAQ</a></li>
 					<li><a href="/voice-chats" class="">Voice Chats</a></li>
@@ -38,7 +38,7 @@
 			</li>
 			<li><a href="/industries" class="">Industries</a></li>
 			<li><a href="/initiatives" class="">Initiatives</a></li>
-			<li><a href="/post" class="">Blog</a></li>
+			<li><a href="/post" class="">News and Media</a></li>
 			<!-- <li><a href="/paper" class="">Papers</a></li> -->
 			<li><a href="/voice_interoperability_form" class="">Workshops</a></li>
 			<li><a href="/contact" class="">Contact</a></li>
@@ -47,7 +47,7 @@
 	</nav>
 	<div class="mobile">
 		<ul class="navbar dn">
-			<li><a href="/about" class="">About</a>
+			<li><a href="/about" class="">About Us</a>
 				<ul>
 					<li><a href="/ambassadors" class="">Ambassadors</a></li>
 					<li><a href="/industry-advisor-council" class="">Industry Advisor Council</a></li>
@@ -61,7 +61,7 @@
 					<li><a href="/join/positions-to-hire" class="">Positions to Hire</a></li>
 				</ul>
 			</li>
-			<li><a href="/resources" class="">Resources</a>
+			<li><a href="/resources" class="">Messaging</a>
 				<ul>
 					<li><a href="/faq" class="">FAQ</a></li>
 					<li><a href="/voice-chats" class="">Voice Chats</a></li>
@@ -70,7 +70,7 @@
 			</li>
 			<li><a href="/industries" class="">Industries</a></li>
 			<li><a href="/initiatives" class="">Initiatives</a></li>
-			<li><a href="/post" class="">Blog</a></li>
+			<li><a href="/post" class="">News and Media</a></li>
 			<!-- <li><a href="/paper" class="">Papers</a></li> -->
 			<li><a href="/voice_interoperability_form" class="">Workshops</a></li>
 			<li><a href="/contact" class="">Contact</a></li>


### PR DESCRIPTION
 We need to update the page names and navbar for three areas of the site:

- Rename “Blog” navbar / page name to “News and Media”
- Rename “Resources” navbar / page name to “Messaging”
- Rename “About” navbar / page name to “About Us”

We don't need to update the URLs, but that may happen at some point in the future. 