### PR TITLE
FR OVN Home Page Update

### DIFF
--- a/site/content/post/fe-agent-to-agent-demo.md
+++ b/site/content/post/fe-agent-to-agent-demo.md
@@ -2,7 +2,8 @@
 posttype: featured
 title: First Demo of Agent-to-Agent Interoperability Produced in December 2021
 date: 2022-02-09
-description: OVON’s Architecture Work Group completed a major milestone in December 2021 by creating the first demo of agent-to-agent interoperability. While much work remains, this development marks a turning point in OVON’s efforts in producing standards for voice assistance built around an interoperable environment.
+description: OVON’s Architecture Work Group completed a major milestone.
 image: >-
   /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
 ---
+OVON’s Architecture Work Group completed a major milestone in December 2021 by creating the first demo of agent-to-agent interoperability. While much work remains, this development marks a turning point in OVON’s efforts in producing standards for voice assistance built around an interoperable environment.

--- a/site/content/post/fe-agent-to-agent-demo.md
+++ b/site/content/post/fe-agent-to-agent-demo.md
@@ -1,0 +1,8 @@
+---
+posttype: featured
+title: First Demo of Agent-to-Agent Interoperability Produced in December 2021
+date: 2022-02-09
+description: OVON’s Architecture Work Group completed a major milestone in December 2021 by creating the first demo of agent-to-agent interoperability. While much work remains, this development marks a turning point in OVON’s efforts in producing standards for voice assistance built around an interoperable environment.
+image: >-
+  /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
+---

--- a/site/content/post/fe-keypublicationstobereleased.md
+++ b/site/content/post/fe-keypublicationstobereleased.md
@@ -2,7 +2,8 @@
 posttype: featured
 title: Key OVON Publications to be Released in March
 date: 2022-02-09
-description: The Open Voice Network has several major publications that will soon be made public to the voice industry. Papers include findings from OVON’s Privacy and Security Work Group, Ethical Use Task Force Community, Architecture Work Group, Health, Wellness, and Life Sciences Community, and more.
+description: The Open Voice Network has several major publications that will soon be made public.
 image: >-
   /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
 ---
+The Open Voice Network has several major publications that will soon be made public to the voice industry. Papers include findings from OVON’s Privacy and Security Work Group, Ethical Use Task Force Community, Architecture Work Group, Health, Wellness, and Life Sciences Community, and more.

--- a/site/content/post/fe-keypublicationstobereleased.md
+++ b/site/content/post/fe-keypublicationstobereleased.md
@@ -1,0 +1,8 @@
+---
+posttype: featured
+title: Key OVON Publications to be Released in March
+date: 2022-02-09
+description: The Open Voice Network has several major publications that will soon be made public to the voice industry. Papers include findings from OVON’s Privacy and Security Work Group, Ethical Use Task Force Community, Architecture Work Group, Health, Wellness, and Life Sciences Community, and more.
+image: >-
+  /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
+---

--- a/site/content/post/fe-ovn-crowsource.md
+++ b/site/content/post/fe-ovn-crowsource.md
@@ -2,7 +2,8 @@
 posttype: info
 title: Crowd Source
 date: 2022-02-07T19:37:19.844Z
-description: Help us accelerate the important work happening at OVON! Crowd-sourced funds will be directly invested in standards research, demo development, and publication.<a class="dim" href="https://crowdfunding.lfx.linuxfoundation.org/initiative/e1ce78fb-9ca5-4746-b6a0-310a0d81f004" target="_blank"> Click Here</a>  to make your donation to the Open Voice Network.
+description: 
 image: >-
   /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
 ---
+Help us accelerate the important work happening at OVON! Crowd-sourced funds will be directly invested in standards research, demo development, and publication.<a class="dim" href="https://crowdfunding.lfx.linuxfoundation.org/initiative/e1ce78fb-9ca5-4746-b6a0-310a0d81f004" target="_blank"> Click Here</a>  to make your donation to the Open Voice Network.

--- a/site/content/post/fe-ovn-crowsource.md
+++ b/site/content/post/fe-ovn-crowsource.md
@@ -1,0 +1,8 @@
+---
+posttype: info
+title: Crowd Source
+date: 2022-02-07T19:37:19.844Z
+description: Help us accelerate the important work happening at OVON! Crowd-sourced funds will be directly invested in standards research, demo development, and publication.<a class="dim" href="https://crowdfunding.lfx.linuxfoundation.org/initiative/e1ce78fb-9ca5-4746-b6a0-310a0d81f004" target="_blank"> Click Here</a>  to make your donation to the Open Voice Network.
+image: >-
+  /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
+---

--- a/site/content/post/fe-ovn-virtual-available.md
+++ b/site/content/post/fe-ovn-virtual-available.md
@@ -1,0 +1,8 @@
+---
+posttype: info
+title: OVON Virtual Ambassador Now Available on Google Assistant and Amazon Alexa
+date: 2022-02-07T19:37:19.844Z
+description: Meet our Virtual Ambassador! Say “Hey Google/Alexa, open OVON Ambassador” or click here for the <a href="https://assistant.google.com/services/invoke/uid/00000092e88bc874/alm/CgSBbxhMEgIQAQ==?hl=en" target="_blank">Google Action</a> or <a href="https://alexa-skills.amazon.com/apis/custom/skills/amzn1.ask.skill.b2610930-b9e7-4bcf-872d-9419b0345eea/launch" target="_blank">Alexa</a>. You can ask our Virtual Ambassador questions about the Open Voice Network and the work we’re doing in voice.
+image: >-
+  /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
+---

--- a/site/content/post/fe-ovn-virtual-available.md
+++ b/site/content/post/fe-ovn-virtual-available.md
@@ -2,7 +2,7 @@
 posttype: info
 title: OVON Virtual Ambassador Now Available on Google Assistant and Amazon Alexa
 date: 2022-02-07T19:37:19.844Z
-description: Meet our Virtual Ambassador! Say “Hey Google/Alexa, open OVON Ambassador” or click here for the <a href="https://assistant.google.com/services/invoke/uid/00000092e88bc874/alm/CgSBbxhMEgIQAQ==?hl=en" target="_blank">Google Action</a> or <a href="https://alexa-skills.amazon.com/apis/custom/skills/amzn1.ask.skill.b2610930-b9e7-4bcf-872d-9419b0345eea/launch" target="_blank">Alexa</a>. You can ask our Virtual Ambassador questions about the Open Voice Network and the work we’re doing in voice.
-image: >-
-  /img/open-voice-network-ovon-voice-worthy-of-user-trust-blog-introducing-the-ovon-virtual-ambassador.jpg
+description: 
+image: >-  
 ---
+Meet our Virtual Ambassador! Say “Hey Google/Alexa, open OVON Ambassador” or click here for the <a href="https://assistant.google.com/services/invoke/uid/00000092e88bc874/alm/CgSBbxhMEgIQAQ==?hl=en" target="_blank">Google Action</a> or <a href="https://alexa-skills.amazon.com/apis/custom/skills/amzn1.ask.skill.b2610930-b9e7-4bcf-872d-9419b0345eea/launch" target="_blank">Alexa</a>. You can ask our Virtual Ambassador questions about the Open Voice Network and the work we’re doing in voice.

--- a/site/content/post/voice-specific-privacy.md
+++ b/site/content/post/voice-specific-privacy.md
@@ -1,5 +1,6 @@
 ---
 title: Voice Specific Privacy
+postType: featured
 date: 2021-05-04T19:32:28.070Z
 description: >-
   To download and read the full "Privacy Guidelines and Capabilities Unique to

--- a/site/layouts/_default/li-home-featured.html
+++ b/site/layouts/_default/li-home-featured.html
@@ -1,0 +1,29 @@
+<div class="w-100-ns">
+	<div>
+		<h2 class="f3 b lh-title mb1 "> > {{ .Title }}</h2>
+		<p class="mid-gray lh-title mb2">{{ .Date.Format "Mon, Jan 2, 2006" }}</p>
+		<p onclick="toggle(event)" class="link b dib black mb0">more →</p>
+		<p id="info" style="display: none;">{{ .Description | markdownify }}</p>
+		<hr style="border-top: 8px solid #bbb;
+		border-radius: 5px;" />
+	</div>
+</div>
+
+<style>
+	.m-fadeOut {
+		visibility: hidden;
+		opacity: 0;
+		transition: visibility 0s linear 300ms, opacity 300ms;
+	}
+</style>
+<script>
+	function toggle(event) {
+		var elm = event.currentTarget;
+		var targetDiv = elm.nextSibling.nextSibling
+		if (targetDiv.style.display !== "none") {
+			targetDiv.style.display = "none";
+		} else {
+			targetDiv.style.display = "block";
+		}
+	}
+</script>

--- a/site/layouts/_default/li-home-featured.html
+++ b/site/layouts/_default/li-home-featured.html
@@ -9,13 +9,6 @@
 	</div>
 </div>
 
-<style>
-	.m-fadeOut {
-		visibility: hidden;
-		opacity: 0;
-		transition: visibility 0s linear 300ms, opacity 300ms;
-	}
-</style>
 <script>
 	function toggle(event) {
 		var elm = event.currentTarget;

--- a/site/layouts/_default/li-home-featured.html
+++ b/site/layouts/_default/li-home-featured.html
@@ -2,21 +2,28 @@
 	<div>
 		<h2 class="f3 b lh-title mb1 "> > {{ .Title }}</h2>
 		<p class="mid-gray lh-title mb2">{{ .Date.Format "Mon, Jan 2, 2006" }}</p>
-		<p onclick="toggle(event)" class="link b dib black mb0">more →</p>
-		<p id="info" style="display: none;">{{ .Description | markdownify }}</p>
+		<div>{{ .Description }}</div>
+		<p onclick="toggle(event);"  class="link b dib black mb0">...</p>
+		<div style="display: none;" >{{ .Content }}</div>
 		<hr style="border-top: 8px solid #bbb;
-		border-radius: 5px;" />
+		border-radius: 5px;"  />
 	</div>
 </div>
 
 <script>
-	function toggle(event) {
-		var elm = event.currentTarget;
-		var targetDiv = elm.nextSibling.nextSibling
-		if (targetDiv.style.display !== "none") {
-			targetDiv.style.display = "none";
+	function applyDisplay(elm)
+	{
+		if (elm.style.display !== "none") {
+			elm.style.display = "none";
 		} else {
-			targetDiv.style.display = "block";
+			elm.style.display = "block";
 		}
+	}
+	function toggle(event) {		
+		var elm = event.currentTarget;
+		var targetDiv = elm.nextSibling.nextSibling;
+		applyDisplay(targetDiv);
+		var prevDiv = elm.previousSibling.previousSibling;
+		applyDisplay(prevDiv);	
 	}
 </script>

--- a/site/layouts/_default/li-home-info.html
+++ b/site/layouts/_default/li-home-info.html
@@ -1,0 +1,7 @@
+<div class="w-100-ns pa3 bg-grey-1 br1 mb2 db raise">
+	<div class="bg-grey-1 pv4 ">
+		<h2 class="f3 b lh-title mb1 primary">{{ .Title }}</h2>
+		<p class="mid-gray lh-title mb2">{{ .Date.Format "Mon, Jan 2, 2006" }}</p>
+		<p>{{ .Description | markdownify }}</p>
+	</div>
+</div>

--- a/site/layouts/_default/li-home-info.html
+++ b/site/layouts/_default/li-home-info.html
@@ -2,6 +2,7 @@
 	<div class="bg-grey-1 pv4 ">
 		<h2 class="f3 b lh-title mb1 primary">{{ .Title }}</h2>
 		<p class="mid-gray lh-title mb2">{{ .Date.Format "Mon, Jan 2, 2006" }}</p>
-		<p>{{ .Description | markdownify }}</p>
+		<p class="mb0">{{ .Description }}</p>
+		{{ .Content }}
 	</div>
 </div>

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -2,6 +2,8 @@
 
 {{ partial "jumbotron" (dict "imageUrl" .Params.image "title" .Title "subtitle" .Params.subtitle "class" .Params.jumboClass) }}
 
+{{ partial "home-featured" }}
+
 {{ partial "short-text" .Params.blurb}}
 
 

--- a/site/layouts/partials/home-featured.html
+++ b/site/layouts/partials/home-featured.html
@@ -1,0 +1,18 @@
+<!-- <div class="ph3 mw7 center">   -->
+<div class="flex">
+  <div class="flex flex-column w-70-ns flex-ns mhn1-ns flex-wrap flex-wrap">
+    <h2 class="f2 b lh-title mb3">What' New at OVON?</h2>
+    <ul class="flex-ns flex-wrap mhn1-ns pa3">
+      {{ range where (where site.Pages "Type" "post") "Params.posttype" "featured" }}
+      {{ .Render "li-home-featured"}}
+      {{ end }}
+    </ul>
+  </div> 
+  <div class="flex flex-column w-50-ns flex-ns  flex-wrap  flex-wrap">  
+    <ul class="flex-ns flex-wrap mhn1-ns pa3">
+    {{ range where (where site.Pages "Type" "post") "Params.posttype" "info" }}  
+      {{ .Render "li-home-info"}}
+    {{ end }}
+  </ul>  
+  </div>
+</div>

--- a/site/layouts/partials/home-featured.html
+++ b/site/layouts/partials/home-featured.html
@@ -1,4 +1,3 @@
-<!-- <div class="ph3 mw7 center">   -->
 <div class="flex mw7 mt4 center">
   <div class="flex flex-column w-50-ns flex-ns mhn1-ns flex-wrap flex-wrap">
     <h2 class="f2 b lh-title mb3">What' New at OVON?</h2>

--- a/site/layouts/partials/home-featured.html
+++ b/site/layouts/partials/home-featured.html
@@ -1,5 +1,5 @@
-<div class="flex mw7 mt4 center">
-  <div class="flex flex-column w-50-ns flex-ns mhn1-ns flex-wrap flex-wrap">
+<div class="flex mw7 mt4 center flex-wrap">
+  <div class="flex flex-column w-50-ns flex-ns mhn1-ns">
     <h2 class="f2 b lh-title mb3">What' New at OVON?</h2>
     <ul class="flex-ns flex-wrap mhn1-ns pa3">
       {{ range where (where site.Pages "Type" "post") "Params.posttype" "featured" }}
@@ -7,7 +7,7 @@
       {{ end }}
     </ul>
   </div> 
-  <div class="flex flex-column w-50-ns flex-ns  flex-wrap  flex-wrap">  
+  <div class="flex flex-column w-50-ns flex-ns">  
     <ul class="flex-ns flex-wrap mhn1-ns pa3">
     {{ range where (where site.Pages "Type" "post") "Params.posttype" "info" }}  
       {{ .Render "li-home-info"}}

--- a/site/layouts/partials/home-featured.html
+++ b/site/layouts/partials/home-featured.html
@@ -1,6 +1,6 @@
 <!-- <div class="ph3 mw7 center">   -->
-<div class="flex">
-  <div class="flex flex-column w-70-ns flex-ns mhn1-ns flex-wrap flex-wrap">
+<div class="flex mw7 mt4 center">
+  <div class="flex flex-column w-50-ns flex-ns mhn1-ns flex-wrap flex-wrap">
     <h2 class="f2 b lh-title mb3">What' New at OVON?</h2>
     <ul class="flex-ns flex-wrap mhn1-ns pa3">
       {{ range where (where site.Pages "Type" "post") "Params.posttype" "featured" }}


### PR DESCRIPTION
**- Summary**

Added the ability to display featured and info posts on the home page.


**- Description for the changelog**

This required modification to the index,html to render a new home-featured partial. The home-featured partial will pull in posts that have a posttype attribute of inform or feature. Based on the posttype it will render featured items on the left and inform items on the right. They are using li-home-info and li-home-featured to render list items. For testing I included markdown for posts.
