### PR TITLE
set post type to required:false

### DIFF
--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -13,7 +13,7 @@ collections: # A list of collections the CMS should be able to edit
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - {label: "Title", name: "title", widget: "string"}
-      - {label: "Post Type", name: "posttype", widget: "string"}
+      - {label: "Post Type", name: "posttype", widget: "string",required: false}
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Intro Blurb", name: "description", widget: "text"}
       - {label: "Image", name: "image", widget: "image", required: false}


### PR DESCRIPTION
**- Summary**

Set the post type field required: false.


**- Description for the changelog**
Within the static/admin/config.yml file update the post collections attribute "Post Type" so that it is not a required value.

