### PR TITLE
audio wall below recorder

### DIFF
--- a/site/content/audio-reviews/_index.md
+++ b/site/content/audio-reviews/_index.md
@@ -5,7 +5,9 @@ recorder: >-
   <div id="witlingo-radio-recorder" data-id="9619248016"
   data-url="https://radio.witlingo.com"></div><script
   src="https://radio.witlingo.com/js/embed/recorder"></script>
+audiowall: >-
+  <div id="audio-wall" data-id="9619248016" data-url="https://radio.witlingo.com"></div><script src="https://radio.witlingo.com/js/embed/audiowall"></script>
 ---
 Our mission is to make voice worthy of user trust, and you are part of this mission. What value does the Open Voice Network bring to your organization? Why do you believe in the mission of the Open Voice Network?  We want to hear your voice. Click the “Go!” button below to record and upload your audio review.
 
-<div id="audio-wall" data-id="9619248016" data-url="https://radio.witlingo.com"></div><script src="https://radio.witlingo.com/js/embed/audiowall"></script>
+

--- a/site/layouts/section/audio-reviews.html
+++ b/site/layouts/section/audio-reviews.html
@@ -10,6 +10,10 @@
   <div class="center mw5 mv4">
     {{ .Params.recorder | safeHTML}}
   </div>
+
+  <div class="center mb4">
+    {{ .Params.audiowall | safeHTML}}
+  </div>
 </div>
 
 {{ end }}

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -350,6 +350,7 @@ collections: # A list of collections the CMS should be able to edit
           - {label: Title, name: title, widget: string}
           - {label: Image, name: image, widget: image}
           - {label: Recorder Snippet, name: recorder, widget: text}
+          - {label: Audio Wall Snippet, name: audiowall, widget: text}
           - {label: Body, name: body, widget: markdown}
       - file: "site/content/events/_index.md"
         label: "Events Page"

--- a/site/static/config.yml
+++ b/site/static/config.yml
@@ -7,12 +7,58 @@ media_folder: "site/static/img" # Folder where user uploaded files should go
 public_folder: "img"
 
 collections: # A list of collections the CMS should be able to edit
+  - name: "events" # Used in routes, ie.: /admin/collections/:slug/edit
+    label: "events" # Used in the UI, ie.: "New Post"
+    folder: "site/content/events" # The path to the folder where the documents are stored
+    create: true # Allow users to create new documents in this collection
+    fields: # The fields each document in this collection have
+      - {label: "List Item Title", name: "listItemTitle", widget: "string"}
+      - {label: "List Item Image", name: "listItemImage", widget: "image"}
+      - {label: "Publish Date", name: "date", widget: "datetime"}
+      - {label: "List Item Image Call to Action Text", name: "callToAction", widget: "string"}
+      - {label: "Event Date", name: "eventDate", widget: "datetime"}
+      - {label: "Presenters Section Header", name: "presentersHeaderText", widget: "string", required: false}
+      - {label: "Bio Section Header", name: "bioHeaderText", widget: "string", required: false}
+      - {label: "Sponsors Section Header", name: "sponsorsHeaderText", widget: "string", required: false}
+      - {label: "Event Page Header Image", name: "pageHeaderBckImge", widget: "image", required: false}
+      - {label: "Event Title", name: "eventTitle", widget: "string", required: false}
+      - {label: "Event Sub Title", name: "eventSubTitle", widget: "string", required: false}
+      - {label: "Event Description", name: "eventDescription", widget: "string", required: false}
+      - {label: "Event Information Image", name: "eventInfoImage", widget: "image", required: false}
+      - {label: "Event Information Image go to link", name: "eventInfoImageLink", widget: "string", required: false}
+      - {label: "Event Registration URL", name: "eventRegisterationUrl", widget: "string", required: false}
+      - {label: "Event Sessions Header Image", name: "eventSessionsHeaderImage", widget: "image", required: false}
+      - label: Sessions
+        widget: list
+        name: eventSessions
+        fields:
+          - {label: "Time Slot", name: "timeslot", widget: "string"}
+          - {label: "Topic", name: "topic", widget: "string"}
+          - label: Presenters
+            name: presenters
+            widget: list
+            fields: 
+              - {label: "Presenter Name", name: "name", widget: "string"}
+      - label: Participant Bios
+        name: eventParticipantBios
+        widget: list
+        fields:
+          - {label: "Name", name: "name", widget: "string"}
+          - {label: "Bio", name: "bio", widget: "text"}
+          - {label: "Photo Url", name: "photoUrl", widget: "image"}
+      - label: Sponsors
+        name: eventSponsors
+        widget: list
+        fields:
+          - {label: "Name", name: "name", widget: "string"}
+          - {label: "Details", name: "details", widget: "text"}          
   - name: "post" # Used in routes, ie.: /admin/collections/:slug/edit
     label: "Post" # Used in the UI, ie.: "New Post"
     folder: "site/content/post" # The path to the folder where the documents are stored
     create: true # Allow users to create new documents in this collection
     fields: # The fields each document in this collection have
       - {label: "Title", name: "title", widget: "string"}
+      - {label: "Post Type", name: "posttype", widget: "string",required: false}
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Intro Blurb", name: "description", widget: "text"}
       - {label: "Image", name: "image", widget: "image", required: false}
@@ -30,7 +76,7 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "pages"
     label: "Pages"
-    files:
+    files:      
       - file: "site/content/_index.md"
         label: "Home Page"
         name: "home"
@@ -304,6 +350,7 @@ collections: # A list of collections the CMS should be able to edit
           - {label: Title, name: title, widget: string}
           - {label: Image, name: image, widget: image}
           - {label: Recorder Snippet, name: recorder, widget: text}
+          - {label: Audio Wall Snippet, name: audiowall, widget: text}
           - {label: Body, name: body, widget: markdown}
       - file: "site/content/events/_index.md"
         label: "Events Page"


### PR DESCRIPTION
As you can see on the [live page](https://openvoicenetwork.org/audio-reviews/), we've added a function from Witlingo called the "audio wall" where the submissions can be displayed. We just need to move the audio wall below the submission recorder.