### PR TITLE
content_change_sponsoring_member_cta_buttons

### DIFF
--- a/site/content/sponsoring_member/_index.md
+++ b/site/content/sponsoring_member/_index.md
@@ -1,6 +1,19 @@
 ---
 title: Sponsoring Member
 image: /img/ovn-open-voice-network-join-ai-voice-assistance_optimized.jpg
+ctas:
+  - type: >-
+      join
+    title: >-
+      Become a Sponsoring Member
+    url: >-
+      https://enrollment.lfx.linuxfoundation.org/?project=open-voice-network 
+  - type: >-
+      register
+    title: >-
+      Become a Sponsoring Member
+    url: >-
+      https://enrollment.lfx.linuxfoundation.org/?project=open-voice-network 
 hardsell:
   - description: >-
       Is your enterprise or organization interested in contributing to the Open

--- a/site/layouts/partials/call_to_action.html
+++ b/site/layouts/partials/call_to_action.html
@@ -1,0 +1,3 @@
+<div class="tc mb3">
+    <a href='{{.url}}' target="_blank" class="btn w-100 w-auto-ns raise" >{{.title}}</a>
+</div>

--- a/site/layouts/section/sponsoring_member.html
+++ b/site/layouts/section/sponsoring_member.html
@@ -13,13 +13,14 @@
 
 {{ partial "table" .Params.pricing }}
 
-<div class="tc mb4">
-<a href="/contact" class="btn w-100 w-auto-ns raise" >Contact Us To Join</a>
-</div>
+{{ $ctas := .Params.ctas}}
+
+{{ range first 1 (where $ctas ".type" "register")}}
+{{ partial "call_to_action" (dict "url" .url "title" .title) }}
+{{end}}
 
 <!-- Full-width image -->
 <img src="{{ .Params.full_image }}" alt="" class="db w-100">
-
 
 <div class="pt4 pb4">
 {{ partial "blockquote" (index .Params.testimonials 0) }}
@@ -27,8 +28,8 @@
 
 {{ partial "4-up" .Params.intro }}
 
-<div class="tc mb3">
-<a href="/contact" class="btn w-100 w-auto-ns raise" >Join Now</a>
-</div>
+{{ range first 1 (where $ctas ".type" "register")}}
+{{ partial "call_to_action" (dict "url" .url "title" .title) }}
+{{end}}
 
 {{ end }}

--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -230,6 +230,13 @@ collections: # A list of collections the CMS should be able to edit
         label: "Sponsoring Member"
         name: "sponsoring_member"
         fields:
+          - label: Call to Actions
+            widget: list
+            name: ctas
+            fields:
+              - {label: "Button Name", name: "type", widget: "string"}
+              - {label: "Button Links", name: "url", widget: "string"}
+              - {label: "Button Text", name: "title", widget: "string"}          
           - {label: Title, name: title, widget: string}
           - {label: Image, name: image, widget: image}
           - {label: Hardsell, name: hardsell, widget: list, fields: [{label: Heading, name: heading, widget: string}, {label: Description, name: description, widget: text} ]}

--- a/site/static/config.yml
+++ b/site/static/config.yml
@@ -230,6 +230,13 @@ collections: # A list of collections the CMS should be able to edit
         label: "Sponsoring Member"
         name: "sponsoring_member"
         fields:
+           - label: Call to Actions
+            widget: list
+            name: ctas
+            fields:
+              - {label: "Button Name", name: "type", widget: "string"}
+              - {label: "Button Links", name: "url", widget: "string"}
+              - {label: "Button Text", name: "title", widget: "string"}
           - {label: Title, name: title, widget: string}
           - {label: Image, name: image, widget: image}
           - {label: Hardsell, name: hardsell, widget: list, fields: [{label: Heading, name: heading, widget: string}, {label: Description, name: description, widget: text} ]}


### PR DESCRIPTION
**- Summary**
This change covers changing the text and url for both buttons on the Sponsoring Members page. Additionally create partial component for buttons(CTA) and added ability to content management pages.

**- Description **

Change the following files:
add new partial component for rendering CTA buttons:
site/layouts/partials/call_to_action.html
added CTA content to the markdown file
site/content/sponsoring_member/_index.md
updated the layout file to use new CTA partial component:
site/layouts/section/sponsoring_member.html
added ability to config yaml to add\edit CTA for content management

