### PR TITLE
open graph and twitter meta tags

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -26,7 +26,7 @@
 	<meta property="og:type" content="business.business">
 	<meta property="og:title" content="{{ .Title }} | {{ $.Site.Title }}">
 	<meta property="og:url" content="/">
-	<meta property="og:image" content="{{ .Params.image }}">
+	<meta property="og:image" content="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}{{ .Params.image }}">
 	<meta property="og:description" content="">
 	<!-- Twitter Graph -->
 	<meta name="twitter:card" content="summary_large_image">

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -24,9 +24,13 @@
 
 	<!-- Open Graph -->
 	<meta property="og:type" content="business.business">
-	<meta property="og:title" content="Open Voice Network | Voice for everyone">
+	<meta property="og:title" content="{{ .Title }} | {{ $.Site.Title }}">
 	<meta property="og:url" content="/">
-	<meta property="og:image" content="/img/open-voice-network-branding.jpg">
+	<meta property="og:image" content="{{ .Params.image }}">
+	<meta property="og:description" content="">
+	<!-- Twitter Graph -->
+	<meta name="twitter:card" content="summary_large_image">
+
   {{ template "_internal/google_analytics.html" . }}
   
   {{ if .IsHome }}

--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -25,7 +25,7 @@
 	<!-- Open Graph -->
 	<meta property="og:type" content="business.business">
 	<meta property="og:title" content="{{ .Title }} | {{ $.Site.Title }}">
-	<meta property="og:url" content="/">
+	<meta property="og:url" content="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}{{ .RelPermalink }}">
 	<meta property="og:image" content="{{ if getenv "CONTEXT" }}{{ cond (eq "production" (getenv "CONTEXT")) (getenv "URL") (getenv "DEPLOY_PRIME_URL") }}{{ else }}{{ $.Site.BaseURL }}{{ end }}{{ .Params.image }}">
 	<meta property="og:description" content="">
 	<!-- Twitter Graph -->


### PR DESCRIPTION
Hope all is well. We've been talking recently about how the current OVON site lacks functionality for adding meta/featured images to appear in social media link previews. Do you know if that's something that is possible to add in? And if so, is that something you would be interested in working on?

Currently all page and post URLs load the original home page header image, attached below. It would be great if we could also edit the meta title and description, but I think just having the ability to insert custom images would be a huge improvement. Let me know what you think or if you have any questions.

Preview from Slack: with Title updated per page, and the jumbo hero image:
<img width="604" alt="image" src="https://user-images.githubusercontent.com/2237576/169587282-5cd0955e-b7b8-43ed-ae31-0f95bba33aa8.png">
