### PR TITLE
CR Webinar Page Update - Date Value and Sort Update

### DIFF
--- a/site/layouts/_default/list-webinars-past.html
+++ b/site/layouts/_default/list-webinars-past.html
@@ -1,7 +1,7 @@
 <div class="w-auto center flex flex-row flex-wrap mb4">
-    {{$past_events := where ( where .Pages "Type" "webinars") "Params.enabled" true   }}
+    {{$past_items := where ( where .Pages "Type" "webinars") "Params.enabled" true   }}
     {{ $counter := 0 }}
-    {{ range sort $past_events }}
+    {{ range sort (first 6 $past_items) ".Params.enddate" "desc" }} 
     {{ $endDate := time .Params.endDate }}
     {{ if lt $endDate.YearDay now.YearDay }}
     {{ $counter = add $counter 1 }}

--- a/site/layouts/_default/list-webinars-upcoming.html
+++ b/site/layouts/_default/list-webinars-upcoming.html
@@ -1,7 +1,7 @@
 <div class="w-100 center flex flex-row flex-wrap mb4">   
-    {{$future_events := where (where .Pages "Type" "webinars") "Params.enabled" true }}
+    {{$items := where (where .Pages "Type" "webinars") "Params.enabled" true }}
     {{ $counter := 0 }}
-    {{ range sort $future_events }}
+    {{ range sort (first 6 $items) ".Params.enddate" "desc" }} 
     {{ $endDate := time .Params.endDate }}
     {{ if ge $endDate.YearDay now.YearDay }}
     {{ $counter = add $counter 1 }}

--- a/site/layouts/events/item.html
+++ b/site/layouts/events/item.html
@@ -2,7 +2,7 @@
   <div onclick="location.href='{{ .RelPermalink }}'" class="mw7 bg-grey-1 raise pa4-s pa2 ma1 vh-auto min-vh-auto">  
     <div>     
     <img src="{{ .Params.listItemImage }}" alt="" 
-    class="w-100 event-logo db mb1 " >`
+    class="w-100 event-logo db mb1" >
     </div>
     <div class="tc pb4">
         <p>{{ .Params.listItemTitle }}</p>

--- a/site/layouts/webinars/item.html
+++ b/site/layouts/webinars/item.html
@@ -1,14 +1,22 @@
-<div class="w-100 bg-grey-1 raise pa4-s pa2 ma1 ma2-l vh-auto min-vh-auto">  
+<div class="w-100 bg-grey-1 raise pa4-s pa2 ma1 ma2-l vh-auto min-vh-auto">
     <!-- <a href="{{ .RelPermalink }}" class="no-underline"> -->
-    <!-- check if videoUrl, if videoUrl it will superseed other variables -->
+    <!-- check if videoUrl, if videoUrl it will superseed other variables -->  
     {{ if ne .Params.videoUrl nil }}
+    <div class="tc pb4">
     {{ partial "video_player" (dict "videoUrl" .Params.videoUrl "title" .Params.title) }}
+    </div>   
+    <div class="tc center fixed bottom-0 pb2 w-100 " style="align-items: center;justify-content: center;">
+        <div class="static w-100">
+            <p class="red"> {{ time.Format "2 January, 2006" .Params.endDate}}</p>
+        </div>
+    </div>
     {{ else }}
-    
+
     <img src="{{ .Params.imageUrl }}" alt="" class="w-100 event-logo db mb1 ">
     {{if ne .Params.callToActionEvent nil }}
     <div class="tc">
         <p>{{ .Params.title}}</p>
+        <p class="red"> {{ time.Format "2 January, 2006" .Params.endDate}}</p>
         <a href="/events/{{.Params.callToActionEvent}}" target="_blank" rel="noopener"
             class="btn raise">{{.Params.callToAction}}</a>
     </div>


### PR DESCRIPTION
**- Summary**

Add the webinar end date value to the webinar list page and sort items by latest end date.

**- Description for the changelog**

Modified list-webinars-past, list-webinars-upcoming to include the date value and adjusted sort logic.
